### PR TITLE
Consider it complete, even if with an error

### DIFF
--- a/NetWebView2Lib.au3
+++ b/NetWebView2Lib.au3
@@ -29,7 +29,8 @@ Global Enum _
 		$WEBVIEW2__NAVSTATUS__STARTING, _
 		$WEBVIEW2__NAVSTATUS__URL_CHANGED, _
 		$WEBVIEW2__NAVSTATUS__COMPLETED, _
-		$WEBVIEW2__NAVSTATUS__TITLE_CHANGED
+		$WEBVIEW2__NAVSTATUS__TITLE_CHANGED, _
+		$WEBVIEW2__NAVSTATUS__NAV_ERROR
 
 #Region ; NetWebView2Lib UDF - core function
 ; #FUNCTION# ====================================================================================================================
@@ -584,6 +585,10 @@ Func __NetWebView2_WebViewEvents__OnMessageReceived($sMsg)
 				; Filter minor resize glitches
 				If $iW > 50 And $iH > 50 Then __NetWebView2_Log(@ScriptLineNumber, $s_Prefix & $iW & "x" & $iH, 1)
 			EndIf
+
+		Case "NAV_ERROR"
+			__NetWebView2_NavigationStatus($WEBVIEW2__NAVSTATUS__NAV_ERROR) ; Consider it complete, even if with an error
+
 		Case Else
 			__NetWebView2_Log(@ScriptLineNumber, $s_Prefix & (StringLen($sMsg) > 150 ? StringLeft($sMsg, 150) & "..." : $sMsg), 1)
 	EndSwitch
@@ -709,4 +714,5 @@ Func __NetWebView2_WebViewEvents__OnContextMenu($sMenuData)
 	__NetWebView2_Log(@ScriptLineNumber, $s_Prefix, 1)
 EndFunc   ;==>__NetWebView2_WebViewEvents__OnContextMenu
 #EndRegion ; NetWebView2Lib UDF - === EVENT HANDLERS ===
+
 


### PR DESCRIPTION
I've updated the Global Enum and the OnMessageReceived function to include a NAV_ERROR state. This prevents the _NetWebView2_LoadWait function from getting stuck in an infinite loop when a navigation fails, which previously caused the GUI to become unresponsive.

> [!IMPORTANT]
> Thanks for your effort and interest 💛 in improving the project. It's very appreciated.

## Description

<!-- Describe the purpose and main changes of this Pull Request (PR), including the problem it solves or the improvement it brings. -->

#### 🔗 Linked GitHub Issues

<!-- In case this addresses a GitHub issue, please link it here. -->

Closes #\<number>

#### 📋 What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

#### 🚀 What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

<br>

## Type of changes

- [x] 🪲 Bugfix (change which fixes an issue)
- [ ] ⭐ New Feature (change which adds functionality)
- [ ] 🔒 Security fix (change which improves security)
- [ ] 🔮 Code style update (formatting, renaming)
- [ ] 🔨 Refactoring (code optimization without functional change)
- [ ] 📚 Documentation (updates to README or docs)
- [ ] ⚙️ Build or CI related changes
- [ ] 🧿 Other type <!-- please describe -->

<br>

## Breaking changes 🔥

<!-- Does this PR introduce breaking changes to existing functionality? If yes, please describe what will break and what users need to do to adapt. -->

- [ ] Yes <!-- please describe -->
- [ ] No

<br>

## How and where was this tested?

#### 🖥️ Describe where you tested your changes

*System:*

- [ ] Windows 11 (x64)
- [ ] Windows 10 (x64)
- [ ] Windows 10 (x86)
- [ ] other Windows version
- [ ] other operating system

*Context:*

- [ ] in Browser \<name and version>
- [ ] with Go \<version>
- [ ] with Node.js \<version>
- [ ] with AutoIt \<version>
- [ ] with .NET (C#) \<version>
- [ ] with ...

#### 🔬 Describe how you tested your changes

- [ ] Manually tested in system and context shown above
- [ ] Ran automatic tests (unit tests, integration tests, etc.)
- [ ] Other ways <!-- please describe -->

<br>

## Checklist

- [ ] I have read and understood the available contributing guidelines.
- [ ] I have ensured my code follows the available code conventions.
- [ ] I have reviewed my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] I have added/updated necessary tests to cover the changes (if applicable).
- [ ] I have checked for potential security implications.

<br>

## Additional context

<!-- Add any other context about the problem or improvement here, if relevant. -->

#### Screenshots

<!-- If relevant, provide before/after comparisons or GIFs of UI changes. -->

#### Note to reviewers

<!-- Add any notes for reviewers here. -->
